### PR TITLE
Created wrap files for utfcpp-2.3.5

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,5 @@
+project('utfcpp', 'cpp', version: '2.3.5', license: 'MIT')
+
+utfcpp_dep = declare_dependency(
+  include_directories: include_directories('source')
+)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+directory = utfcpp-2.3.5
+source_url = https://github.com/nemtrif/utfcpp/archive/v2.3.5.zip
+source_filename = utfcpp-2.3.5.zip
+source_hash = 1d5cb7d908202d734ec35b84087400013f352ffb4612e978ffb948986b76df14


### PR DESCRIPTION
Here is wrap file and a `meson.build` file for utfcpp with version 2.3.5. I hope I did everything right, although I'm not sure about license for utfcpp. In it's `README.md` it says:

>  ... check out the license at the beginning of the utf8.h file. ...

And as far as I can tell, [it is a MIT License][1].

[1]: https://github.com/nemtrif/utfcpp/blob/master/source/utf8.h#L4